### PR TITLE
Send log records in batch to Kinesis Firehose

### DIFF
--- a/firehose.go
+++ b/firehose.go
@@ -198,8 +198,6 @@ func (adapter *Adapter) batchPutToFirehose() {
 		case record := <-adapter.deliver:
 			{
 
-				adapter.logD("batch: %v \n", record)
-
 				// buffer, and optionally flush
 				bytes, err := json.Marshal(record)
 				if err != nil {

--- a/firehose.go
+++ b/firehose.go
@@ -356,7 +356,9 @@ func extractKubernetesInfo(container *docker.Container) *ContainerInfo {
 		fullPod := container.Config.Labels["io.kubernetes.pod.name"]
 		pod := strings.Split(container.Config.Labels["io.kubernetes.pod.name"], "-")
 		podPrefix := fullPod
-		if len(pod) > 0 {
+		if len(pod) > 2 {
+			podPrefix = strings.Join(pod[:len(pod)-2], "-")
+		} else if len(pod) > 0 {
 			podPrefix = pod[0]
 		}
 		return &ContainerInfo{

--- a/firehose.go
+++ b/firehose.go
@@ -3,19 +3,37 @@ package raw
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/gliderlabs/logspout/router"
 )
 
+var (
+	bufferSizeEnv      = "FIREHOSE_BUFFERSIZE"
+	flushTimeoutEnv    = "FIREHOSE_FLUSH_TIMEOUT"
+	requestLimitEnv    = "FIREHOSE_REQUEST_LIMIT"
+	overhead           = 1024
+	firehoseSizeLimit  = (4*1024 - overhead) * 1000
+	firehoseBatchLimit = 500
+)
+
 type Adapter struct {
-	route              *router.Route
-	svc                *firehose.Firehose
-	deliveryStreamName string
+	route                *router.Route
+	svc                  *firehose.Firehose
+	deliveryStreamName   *string
+	deliver              chan *Record
+	bufferSize           int
+	flushTimeout         time.Duration
+	firehoseRequestLimit int
+	debugLog             bool
 }
 
 type Record struct {
@@ -43,17 +61,57 @@ func NewRawAdapter(route *router.Route) (router.LogAdapter, error) {
 		return nil, errors.New("delivery stream name required in format firehose://<stream-name>")
 	}
 
+	bufferSize := firehoseBatchLimit
+	if os.Getenv(bufferSizeEnv) != "" {
+		bufferSize, err = strconv.Atoi(os.Getenv(bufferSizeEnv))
+		if err != nil {
+			return nil, fmt.Errorf("Invalid %s env var: %v", bufferSizeEnv, os.Getenv(bufferSizeEnv))
+		}
+	}
+
+	firehoseRequestLimit := firehoseSizeLimit
+	if os.Getenv(requestLimitEnv) != "" {
+		firehoseRequestLimit, err = strconv.Atoi(os.Getenv(requestLimitEnv))
+		if err != nil {
+			return nil, fmt.Errorf("Invalid %s env var: %v", requestLimitEnv, os.Getenv(requestLimitEnv))
+		}
+	}
+
+	flushTimeout := time.Duration(10) * time.Second
+	if os.Getenv(flushTimeoutEnv) != "" {
+		duration, err := strconv.Atoi(os.Getenv(flushTimeoutEnv))
+		if err != nil {
+			return nil, fmt.Errorf("Invalid %s env var: %v", flushTimeoutEnv, os.Getenv(flushTimeoutEnv))
+		}
+		flushTimeout = time.Duration(duration) * time.Second
+	}
+
+	debug := false
+	if os.Getenv("DEBUG") != "" {
+		log.Println("firehose: activating debug mode")
+		debug = true
+	}
+
 	svc := firehose.New(sess)
 
-	return &Adapter{
-		route:              route,
-		svc:                svc,
-		deliveryStreamName: deliveryStreamName,
-	}, nil
+	streamName := aws.String(deliveryStreamName)
+	adapter := &Adapter{
+		route:                route,
+		svc:                  svc,
+		deliveryStreamName:   streamName,
+		deliver:              make(chan *Record),
+		bufferSize:           bufferSize,
+		flushTimeout:         flushTimeout,
+		firehoseRequestLimit: firehoseRequestLimit,
+		debugLog:             debug,
+	}
+
+	go adapter.batchPutToFirehose()
+
+	return adapter, nil
 }
 
 func (adapter *Adapter) Stream(logstream chan *router.Message) {
-	streamName := aws.String(adapter.deliveryStreamName)
 
 	for message := range logstream {
 
@@ -64,7 +122,7 @@ func (adapter *Adapter) Stream(logstream chan *router.Message) {
 		if err != nil {
 		}
 
-		info := Record{
+		info := &Record{
 			Timestamp:     message.Time,
 			ContainerId:   message.Container.ID,
 			Message:       message.Data,
@@ -74,21 +132,131 @@ func (adapter *Adapter) Stream(logstream chan *router.Message) {
 			Args:          jsonMsg,
 		}
 
-		bytes, err := json.Marshal(info)
+		//adapter.logD("Stream: sending log record to deliver: %v", message.Data)
+
+		adapter.deliver <- info
+	}
+}
+
+func (adapter *Adapter) batchPutToFirehose() {
+	buffer := adapter.newBuffer()
+
+	timeout := time.NewTimer(adapter.flushTimeout)
+	bufferSize := 0
+
+	for {
+		select {
+		case record := <-adapter.deliver:
+			{
+				//adapter.logD("batchPutToFirehose: got a record: %v \n", record)
+
+				// buffer, and optionally flush
+				bytes, err := json.Marshal(record)
+				if err != nil {
+					log.Println("batchPutToFirehose: json marshalling error - ", err)
+				}
+				frecord := &firehose.Record{
+					Data: append(bytes, "\n"...),
+				}
+
+				adapter.logD("batchPutToFirehose: bufferSize: %d, len: %d < %d \n", bufferSize, len(buffer), cap(buffer))
+
+				if len(buffer) == cap(buffer) || bufferSize+len(frecord.Data) >= adapter.firehoseRequestLimit {
+					timeout.Reset(adapter.flushTimeout)
+					go adapter.flushBuffer(buffer)
+					buffer = adapter.newBuffer()
+					bufferSize = 0
+				}
+
+				bufferSize = bufferSize + len(frecord.Data)
+				buffer = append(buffer, frecord)
+			}
+		case <-timeout.C:
+			{
+				// flush
+				adapter.logD("batchPutToFirehose: timeout: %d, len: %d < %d \n", bufferSize, len(buffer), cap(buffer))
+				if len(buffer) > 0 {
+					go adapter.flushBuffer(buffer)
+					buffer = adapter.newBuffer()
+					bufferSize = 0
+				}
+				timeout.Reset(adapter.flushTimeout)
+			}
+		}
+	}
+}
+
+func (adapter *Adapter) newBuffer() []*firehose.Record {
+	return make([]*firehose.Record, 0, adapter.bufferSize)
+}
+
+func (adapter *Adapter) flushBuffer(buffer []*firehose.Record) error {
+	// flush
+	params := &firehose.PutRecordBatchInput{
+		DeliveryStreamName: adapter.deliveryStreamName,
+		Records:            buffer,
+	}
+
+	err := retry(3, 2*time.Second, func() error {
+		adapter.logD("flushBuffer (retry): sending %d records\n", len(buffer))
+		response, err := adapter.svc.PutRecordBatch(params)
 		if err != nil {
-			log.Println("firehose: ", err)
+			adapter.logD("flushBuffer (retry): result %v\n", err)
+			if aerr, ok := err.(awserr.Error); ok {
+				switch aerr.Code() {
+				case firehose.ErrCodeServiceUnavailableException:
+					adapter.logD("firehose: service unavailable: %s - retrying\n", err)
+					return err
+				default:
+					return stop{err}
+				}
+			}
+		}
+		if response != nil && *response.FailedPutCount > 0 {
+			adapter.logD("firehose: %d records failed - retrying\n", *response.FailedPutCount)
+			// re-arrange buffer to keep only failed records
+			buffer := make([]*firehose.Record, 0, *response.FailedPutCount)
+			for i, r := range response.RequestResponses {
+				if r.ErrorCode != nil {
+					buffer = append(buffer, params.Records[i])
+				}
+			}
+			params.SetRecords(buffer)
+			return fmt.Errorf("retrying %d failed records", *response.FailedPutCount)
+		}
+		adapter.logD("flushBuffer (retry): everything has been sent\n")
+		return nil
+	})
+
+	adapter.logD("flushBuffer (abort/ok): %v\n", err)
+	if err != nil {
+		log.Println("firehose: batch error", err.Error())
+	}
+	return err
+}
+
+func retry(attempts int, sleep time.Duration, fn func() error) error {
+	if err := fn(); err != nil {
+		if s, ok := err.(stop); ok {
+			// Return the original error for later checking
+			return s.error
 		}
 
-		params := &firehose.PutRecordInput{
-			DeliveryStreamName: streamName,
-			Record: &firehose.Record{
-				Data: append(bytes, "\n"...),
-			},
+		if attempts--; attempts > 0 {
+			time.Sleep(sleep)
+			return retry(attempts, 2*sleep, fn)
 		}
+		return err
+	}
+	return nil
+}
 
-		_, err = adapter.svc.PutRecord(params)
-		if err != nil {
-			log.Println("firehose: ", err)
-		}
+type stop struct {
+	error
+}
+
+func (adapter *Adapter) logD(format string, args ...interface{}) {
+	if adapter.debugLog {
+		log.Printf("firehose: "+format, args...)
 	}
 }

--- a/firehose_test.go
+++ b/firehose_test.go
@@ -1,0 +1,42 @@
+package raw
+
+import (
+	"testing"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+func Test_extractKubernetesInfo(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    *docker.Container
+		podName string
+		fullPod string
+	}{
+		{"empty labels", container(), "", ""},
+		{"deployment pods", container("io.kubernetes.container.name", "blah", "io.kubernetes.pod.name", "tickettoride-5956cccbf9-d6fqn"), "tickettoride", "tickettoride-5956cccbf9-d6fqn"},
+		{"statefulsets pods", container("io.kubernetes.container.name", "blah", "io.kubernetes.pod.name", "smallworld3-0"), "smallworld3", "smallworld3-0"},
+		{"statefulsets pods v2", container("io.kubernetes.container.name", "blah", "io.kubernetes.pod.name", "metalobby-staging-1"), "metalobby-staging", "metalobby-staging-1"},
+		{"deployment pods all figures", container("io.kubernetes.container.name", "blah", "io.kubernetes.pod.name", "tickettoride-5956cccbf9-23456"), "tickettoride", "tickettoride-5956cccbf9-23456"},
+		{"statefulsets pods 3 components", container("io.kubernetes.container.name", "blah", "io.kubernetes.pod.name", "metalobby-pr-testing-2"), "metalobby-pr-testing", "metalobby-pr-testing-2"},
+		{"deployment pods 3 components", container("io.kubernetes.container.name", "blah", "io.kubernetes.pod.name", "tf-mars-beta-67754f879c-dsx84"), "tf-mars-beta", "tf-mars-beta-67754f879c-dsx84"},
+		{"deployment pods 2 components", container("io.kubernetes.container.name", "blah", "io.kubernetes.pod.name", "tf-mars-66cc86c7cf-lwjlq"), "tf-mars", "tf-mars-66cc86c7cf-lwjlq"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractKubernetesInfo(tt.args)
+			if got.Podprefix != tt.podName || got.Fullpod != tt.fullPod {
+				t.Errorf("extractKubernetesInfo() = %v, want %v/%v", got, tt.podName, tt.fullPod)
+			}
+		})
+	}
+}
+
+func container(el ...string) *docker.Container {
+	labels := make(map[string]string)
+	for i := 0; i < len(el); i += 2 {
+		labels[el[i]] = el[i+1]
+	}
+	return &docker.Container{Config: &docker.Config{Labels: labels}}
+}


### PR DESCRIPTION
Using PutRecord when sending lots of records is very slow and logspout sometimes can't keep up to date, diverging (sometimes drastically) from docker logs.

This change instead batches as much as it can records to send them in one pass.

It push the logs whenever one of these events happen first:
* `FIREHOSE_FLUSH_TIMEOUT` (default 10s) triggers and if there are accumulated records
* `FIREHOSE_BUFFERSIZE` (default 500, max 500) have been accumulated
* `FIREHOSE_REQUEST_LIMIT` (default 3MB) of record data has been accumulated

Sending to firehose is done asynchronously so while we're sending we're also preparing the next batch of records.
Sending is retried if something bad happen on the firehose side (but I wasn't able to test that part).
